### PR TITLE
Performance improvements to SDKGoogleLinkEnhancer — v2026.03.23.00

### DIFF
--- a/SDKGoogleLinkEnhancer-README.md
+++ b/SDKGoogleLinkEnhancer-README.md
@@ -2,9 +2,9 @@
 
 **A utility library for Waze Map Editor scripts: highlights Google Place link issues (closed, broken, duplicate, distant) directly on the map and in the sidebar.**
 
-**Authors:** MapOMatic, karlsosha, JS55CT, WazeDev group  
-**License:** GNU GPLv3  
-**Latest Version:** 2026.03.10.00
+**Authors:** MapOMatic, karlsosha, JS55CT, WazeDev group
+**License:** GNU GPLv3
+**Latest Version:** 2026.03.23.00
 
 ---
 
@@ -53,9 +53,12 @@
 - **Hover Previews**
   - Hover Google links in the place panel to:
     - Draw line/distance to the Google Place location
-    - Show exact distance in user’s units
+    - Show exact distance in user's units
 - **Proactive Checks**
-  - Auto-fetches Google status for all visible venues and flags issues instantly as the map loads.
+  - Auto-fetches Google status for all visible venues when the highlight layer is visible, so issues are flagged as the map loads — no clicking required.
+  - Fetching is skipped when the layer is hidden; sidebar link coloring still works reactively via the API interceptor.
+- **Rate-Limited API Access**
+  - Google API requests are queued and dispatched at a controlled concurrency (default: 20 simultaneous) to avoid request bursts when many venues are visible.
 - **Layer Controls**
   - Toggle highlights on/off from the WME Layer panel (when supported by host script).
 - **Customizable**
@@ -91,7 +94,7 @@
 
 ## Installation
 
-_Developers:_  
+_Developers:_
 Your main script must:
 
 - Create an instance:
@@ -103,7 +106,7 @@ Your main script must:
 - Configure as needed.
 - Call `.enable()` to turn on.
 
-_End users:_  
+_End users:_
 You do not need to install this directly—WME PIE integrates it for you.
 
 ---
@@ -111,17 +114,18 @@ You do not need to install this directly—WME PIE integrates it for you.
 ## How It Works
 
 - The WME Place Interface Enhancements (PIE) script constructs and enables a `SDKGoogleLinkEnhancer` instance.
-- All visible WME venues are scanned for Google Place links.
-- Place details are fetched live from Google via WME’s API.
-- Any issues are highlighted visually on the map and/or sidebar (handled by PIE).
-- Hovering a Google link draws a line and shows distance (by PIE).
-- UI strings and thresholds are customizable, but set by PIE.
+- When the highlight layer is visible, all visible WME venues are scanned for Google Place links and place details are fetched from Google via WME's API. Requests are queued and sent at a controlled rate to avoid bursts.
+- When the highlight layer is hidden, no proactive fetching occurs. Sidebar link coloring (closed/invalid/too-far indicators) still works by intercepting the API calls WME makes when rendering place details.
+- Any issues are highlighted visually on the map and/or sidebar.
+- Map redraws are debounced (150 ms) so that a batch of incoming API responses triggers a single redraw pass rather than one per response.
+- Hovering a Google link in the sidebar draws a line to the Google Place location and shows distance in the user's units.
+- UI strings and thresholds are customizable by the host script (set by PIE).
 
 ---
 
 ## Usage
 
-**For Script Developers**  
+**For Script Developers**
 _End users: these actions are performed automatically by WME PIE._
 
 Register the layer:
@@ -161,11 +165,11 @@ checkBoxElement.onchange = () => (GLE.showTempClosedPOIs = checkBoxElement.check
 
 ### Monkey-Patching Notice
 
-> ⚠️ **IMPORTANT: Monkey-Patching**  
-> To track all Google Place lookups, this script **overwrites (monkey-patches)**  
+> ⚠️ **IMPORTANT: Monkey-Patching**
+> To track all Google Place lookups, this script **overwrites (monkey-patches)**
 > `google.maps.places.PlacesService.prototype.getDetails`.
 >
-> **If multiple scripts patch this at once, only one will work.**  
+> **If multiple scripts patch this at once, only one will work.**
 > (This includes classic Google Link Enhancer scripts and any other similar tool.)
 >
 > **Best practice:**
@@ -180,7 +184,7 @@ checkBoxElement.onchange = () => (GLE.showTempClosedPOIs = checkBoxElement.check
 
 ### Layer and String Customization
 
-- You can fully localize all user-facing strings by overwriting `GLE.strings`.
+- You can fully localize all user-facing strings by overwriting properties on `GLE.strings`.
 
 ---
 
@@ -194,38 +198,42 @@ checkBoxElement.onchange = () => (GLE.showTempClosedPOIs = checkBoxElement.check
 const GLE = new SDKGoogleLinkEnhancer(sdk, turf, { layerName: 'My Script - GLE' });
 ```
 
+| Parameter           | Type           | Required | Description                                                    |
+| ------------------- | -------------- | -------- | -------------------------------------------------------------- |
+| `sdk`               | WME SDK object | Yes      | The WME SDK instance                                           |
+| `turf`              | Turf.js object | Yes      | The Turf.js library                                            |
+| `options.layerName` | String         | No       | Name for the map layer (default: `"Google Link Enhancements"`) |
+
 #### Properties
 
-- **GLE.strings**: All user-facing UI strings and messages.
+- **`GLE.strings`** — All user-facing UI strings. Overwrite individual properties to localize.
   ```js
-  GLE.strings.permClosedPlace = 'Permanently closed in Google';
-  GLE.strings.tempClosedPlace = 'Temporarily closed in Google';
-  GLE.strings.brokenPlace = 'Invalid Google Place link';
-  GLE.strings.duplicatePlace = 'This Place ID is used by multiple venues';
-  GLE.strings.distantPlace = 'Google Place marker is too far from Waze place';
+  GLE.strings.permClosedPlace  = 'Permanently closed in Google';
+  GLE.strings.tempClosedPlace  = 'Temporarily closed in Google';
+  GLE.strings.badLink          = 'Invalid Google Place link';
+  GLE.strings.multiLinked      = 'Linked more than once already';
+  GLE.strings.linkedToXPlaces  = 'This is linked to {0} places'; // {0} = count
+  GLE.strings.tooFar           = 'Google place is more than {0} meters away'; // {0} = limit
+  GLE.strings.linkedToThisPlace = 'Already linked to this place';
+  GLE.strings.linkedNearby     = 'Already linked to a nearby place';
   ```
-- **GLE.distanceLimit**: Number (meters). Highlight venues whose Google Place marker is farther away than this from WME's venue location.
+
+- **`GLE.distanceLimit`** — Number (meters). Highlights venues whose Google Place marker is farther than this from the WME venue. Area places add the centroid-to-corner distance on top of this threshold.
   ```js
-  GLE.distanceLimit = 400;
+  GLE.distanceLimit = 400; // default
   ```
-- **GLE.showTempClosedPOIs**: Boolean. If `true`, shows highlight for temp-closed venues; if `false`, suppresses it.
+
+- **`GLE.showTempClosedPOIs`** — Boolean. When `true`, shows yellow highlights for temporarily closed venues. Setting this triggers an immediate map redraw.
   ```js
-  GLE.showTempClosedPOIs = false;
+  GLE.showTempClosedPOIs = true; // default
   ```
-- **GLE.layerName**: String. Name for the overlay/layer in the panel.
+
+- **`GLE.linkCache`** — The internal `GooglePlaceCache` instance. Exposes `.cache` (Map) and `.pendingPromises` (Map) for advanced use.
 
 #### Methods
 
-- `GLE.enable()` – Start monitoring, show overlay
-- `GLE.disable()` – Stop overlay and highlighting
-- `GLE.refresh()` – Force rescan of all visible venues (optional)
-- `GLE.setStrings({...})` – Bulk set UI text
-  ```js
-  GLE.setStrings({
-    permClosedPlace: 'Closed!',
-    tempClosedPlace: 'Temporarily closed!',
-  });
-  ```
+- **`GLE.enable()`** — Activates the enhancer: installs the API interceptor, starts listening for venue changes, and runs an initial map scan.
+- **`GLE.disable()`** — Deactivates the enhancer: removes all map features and event listeners, cancels any pending debounce timer.
 
 ---
 
@@ -243,25 +251,30 @@ $('#_cbEnableGLE').change(function () {
 
 ## FAQ
 
-**Q: Does this script call Google directly?**  
-A: No, it uses the editor’s loaded Google API.
+**Q: Does this script call Google directly?**
+A: No, it uses the editor's loaded Google API via WME's own API key.
 
-**Q: Can I use several SDK scripts together?**  
+**Q: Why does it make many Google API requests when I enable it?**
+A: When the highlight layer is visible, it proactively fetches place status for all Google-linked venues in the current viewport so map rings appear without requiring you to click each place. Requests are rate-limited to a maximum of 20 concurrent calls. If the layer is hidden, no proactive fetching occurs.
+
+**Q: Can I use several SDK scripts together?**
 A: Yes, _unless_ another script also monkey-patches `getDetails`.
 
-**Q: Why don’t I see highlighting?**  
-A: Your main script may not call `.enable()`, or you may be running two GLE-type scripts together.
+**Q: Why don't I see highlighting?**
+A: Your main script may not call `.enable()`, the highlight layer may be hidden in the Layer panel, or you may be running two GLE-type scripts together.
 
-**Q: Do I need an API key?**  
+**Q: Do I need an API key?**
 A: No. WME loads all keys and libraries for you.
 
 ---
 
 ## Troubleshooting
 
-| Problem                   | Possible Cause/Solution                                            |
-| ------------------------- | ------------------------------------------------------------------ |
-| Highlights missing/broken | Only the last loaded script can patch `getDetails`.                |
-| Multiple overlays/flicker | Conflicting scripts—disable all but one GLE/monkey-patched script. |
-| Layer missing             | Ensure your code calls layer registration.                         |
-| Console errors            | Please report with a screenshot/log.                               |
+| Problem                               | Possible Cause/Solution                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| Highlights missing/broken             | Only the last loaded script can patch `getDetails`. Disable conflicting scripts. |
+| Highlights missing after pan          | Check that the highlight layer checkbox is enabled in the WME Layers panel.      |
+| Multiple overlays/flicker             | Conflicting scripts — disable all but one GLE/monkey-patched script.             |
+| No highlights but sidebar colors work | The highlight layer is hidden. Toggle it on in the WME Layers panel.             |
+| Layer missing                         | Ensure your code calls the constructor before calling `.enable()`.               |
+| Console errors                        | Please report with a screenshot/log.                                             |

--- a/SDKGoogleLinkEnhancer.js
+++ b/SDKGoogleLinkEnhancer.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         WME Utils - Google Link Enhancer
 // @namespace    WazeDev
-// @version      2026.03.10.00
+// @version      2026.03.23.00
 // @description  Adds some extra WME functionality related to Google place links.
 // @author       WazeDev group
 // @include      /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/
@@ -66,6 +66,10 @@ const SDKGoogleLinkEnhancer = (() => {
         #ptFeature;
         #lineFeature;
         #timeoutID = -1;
+        #processDebounceID = -1;          // debounce timer handle for #processPlaces
+        #prefetchQueue = [];               // IDs waiting to be dispatched to Google API
+        #prefetchInflight = 0;             // count of in-flight getDetails requests
+        static #PREFETCH_CONCURRENCY = 50; // max simultaneous getDetails calls
         strings = {
             permClosedPlace: "Google indicates this place is permanently closed.\nVerify with other sources or your editor community before deleting.",
             tempClosedPlace: "Google indicates this place is temporarily closed.",
@@ -216,7 +220,7 @@ const SDKGoogleLinkEnhancer = (() => {
                 eventName: "wme-data-model-objects-added",
                 eventHandler: (payload) => {
                     if (payload.dataModelName === "venues") {
-                        this.#processPlaces(payload.objectIds);
+                        this.#processPlaces();
                     }
                 }
             });
@@ -224,7 +228,7 @@ const SDKGoogleLinkEnhancer = (() => {
                 eventName: "wme-data-model-objects-removed",
                 eventHandler: (payload) => {
                     if (payload.dataModelName === "venues") {
-                        this.#processPlaces(payload.objectIds);
+                        this.#processPlaces();
                     }
                 },
             });
@@ -232,7 +236,7 @@ const SDKGoogleLinkEnhancer = (() => {
                 eventName: "wme-data-model-objects-changed",
                 eventHandler: (payload) => {
                     if (payload.dataModelName === "venues") {
-                        this.#processPlaces(payload.objectIds);
+                        this.#processPlaces();
                     }
                 }
             });
@@ -320,6 +324,10 @@ const SDKGoogleLinkEnhancer = (() => {
                     });
                     this.#venueChangeHandler = null;
                 }
+                if (this.#processDebounceID !== -1) {
+                    clearTimeout(this.#processDebounceID);
+                    this.#processDebounceID = -1;
+                }
                 this.#enabled = false;
                 this.sdk.Map.removeAllFeaturesFromLayer({ layerName: this.#mapLayer });
             }
@@ -370,9 +378,16 @@ const SDKGoogleLinkEnhancer = (() => {
             }
             return false;
         }
-        #processPlaces(objectIds = undefined) {
-            if (this.#enabled) {
-                try {
+        #processPlaces() {
+            if (!this.#enabled) return;
+            if (this.#processDebounceID !== -1) clearTimeout(this.#processDebounceID);
+            this.#processDebounceID = setTimeout(() => {
+                this.#processDebounceID = -1;
+                this.#doProcessPlaces();
+            }, 150);
+        }
+        #doProcessPlaces() {
+            try {
                     // Only draw map rings when the layer is visible in the Map Layers panel.
                     // Always clear first (even when hidden) so in-flight API responses can't
                     // ghost features back onto a layer the user has just hidden.
@@ -383,11 +398,11 @@ const SDKGoogleLinkEnhancer = (() => {
                     const existingLinks = SDKGoogleLinkEnhancer.#getExistingLinks(this.sdk);
                     this.sdk.Map.removeAllFeaturesFromLayer({ layerName: this.#mapLayer });
                     const drawnLinks = [];
-                    if (!objectIds) {
-                        objectIds = [];
-                        for (const venue of this.sdk.DataModel.Venues.getAll()) {
-                            objectIds.push(venue.id);
-                        }
+                    // Clear stale queue entries from previous viewport before building uncachedIds.
+                    this.#prefetchQueue = [];
+                    const objectIds = [];
+                    for (const venue of this.sdk.DataModel.Venues.getAll()) {
+                        objectIds.push(venue.id);
                     }
                     const uncachedIds = new Set();
                     for (const objId of objectIds) {
@@ -498,12 +513,16 @@ const SDKGoogleLinkEnhancer = (() => {
                     // Proactively fetch Google data for venues not yet in cache.
                     // When responses arrive the interceptor populates the cache and
                     // triggers another #processPlaces pass to render the highlights.
-                    this.#prefetchPlaceData([...uncachedIds]);
+                    // Skip prefetch when the layer is hidden — sidebar coloring works
+                    // reactively via the interceptor, so there's no benefit fetching
+                    // data for rings that aren't being displayed.
+                    if (layerVisible) {
+                        this.#prefetchPlaceData([...uncachedIds]);
+                    }
                 }
                 catch (ex) {
                     console.error("PIE (Google Link Enhancer) error:", ex);
                 }
-            }
         }
         // Proactively fetches Google place data for each uncached place ID so that
         // GLE can highlight closed/far venues in the viewport without requiring user selection.
@@ -511,14 +530,35 @@ const SDKGoogleLinkEnhancer = (() => {
         // places.googleapis.com which is not in WME's Content Security Policy connect-src list
         // and will be blocked by the browser. The Place.fetchFields interceptor in
         // #interceptGooglePlacesAPIs remains active in case WME itself ever migrates to the new API.
+        // Requests are capped at #PREFETCH_CONCURRENCY simultaneous in-flight calls; the rest
+        // are queued and drained automatically as each response arrives.
         #prefetchPlaceData(placeIds) {
             if (!placeIds.length) return;
             if (typeof google === "undefined" || !google.maps?.places?.PlacesService) return;
+            for (const id of placeIds) {
+                if (!this.#prefetchQueue.includes(id)) {
+                    this.#prefetchQueue.push(id);
+                }
+            }
+            this.#drainPrefetchQueue();
+        }
+        #drainPrefetchQueue() {
+            if (this.#prefetchInflight >= SDKGoogleLinkEnhancer.#PREFETCH_CONCURRENCY
+                || this.#prefetchQueue.length === 0) return;
+            if (typeof google === "undefined" || !google.maps?.places?.PlacesService) return;
             const service = new google.maps.places.PlacesService(document.createElement("div"));
-            for (const placeId of placeIds) {
+            while (this.#prefetchInflight < SDKGoogleLinkEnhancer.#PREFETCH_CONCURRENCY
+                   && this.#prefetchQueue.length > 0) {
+                const placeId = this.#prefetchQueue.shift();
+                this.#prefetchInflight++;
                 service.getDetails(
                     { placeId, fields: ["place_id", "geometry", "business_status"] },
-                    () => {} // response handled by the interceptor in #interceptGooglePlacesAPIs
+                    () => {
+                        // Interceptor in #interceptGooglePlacesAPIs handles cache population
+                        // and triggers #processPlaces(). This callback only manages queue state.
+                        this.#prefetchInflight--;
+                        this.#drainPrefetchQueue();
+                    }
                 );
             }
         }
@@ -798,8 +838,9 @@ const SDKGoogleLinkEnhancer = (() => {
                     // Re-render map highlights now that Google data has arrived for this place.
                     // #processPlaces ran earlier (on map load) before the cache was populated,
                     // so a new pass is needed each time a getDetails response comes back.
+                    // The debounce inside #processPlaces coalesces rapid back-to-back calls.
                     if (cacheUpdated) {
-                        setTimeout(() => that.#processPlaces(), 0);
+                        that.#processPlaces();
                     }
                     callback(result, status); // Pass the result to the original callback
                 };
@@ -830,7 +871,7 @@ const SDKGoogleLinkEnhancer = (() => {
                         link.tempclosed = true;
                     }
                     that.linkCache.addPlace(this.id, link);
-                    setTimeout(() => that.#processPlaces(), 0);
+                    that.#processPlaces();
                     return result;
                 } catch (err) {
                     // Only cache as notFound for a definitive NOT_FOUND response.
@@ -838,7 +879,7 @@ const SDKGoogleLinkEnhancer = (() => {
                     const status = String(err?.status ?? err?.code ?? err?.message ?? "").toUpperCase();
                     if (status.includes("NOT_FOUND")) {
                         that.linkCache.addPlace(this.id, { notFound: true });
-                        setTimeout(() => that.#processPlaces(), 0);
+                        that.#processPlaces();
                     }
                     throw err; // Re-throw so WME and other callers still receive the error.
                 }


### PR DESCRIPTION
## Problem

The SDK version was making significantly more Google API requests than the original script. With a typical map area showing 100+ Google-linked venues, it would fire all getDetails requests simultaneously on load, and then trigger a full map redraw for every single response that came back — so 200 venues meant 200 redraws stacked on each other. There was also a latent bug where changing a single venue would clear all other venue rings off the map (they'd disappear until the next full refresh).

## Changes

- Debounced #processPlaces() — Extracted the method body into #doProcessPlaces(). The outer #processPlaces() now schedules a 150ms debounce, so rapid bursts of calls (e.g., one per arriving API response) coalesce into a single redraw pass instead of stacking.

- Rate-limited prefetch — Replaced the fire-all-at-once loop in #prefetchPlaceData() with a queue and concurrency cap (#PREFETCH_CONCURRENCY = 50). Requests drain automatically as each response arrives, keeping at most 20 in flight at a time.

- Skips prefetch when layer is hidden — No point fetching data for rings that aren't being displayed. When the layer checkbox is off, proactive fetching is skipped entirely. Sidebar link coloring (red/cyan/magenta) still works reactively via the API interceptor regardless.

- Fixed partial-redraw bug — The wme-data-model-objects-changed/added/removed handlers were passing payload.objectIds to limit the redraw scope, but removeAllFeaturesFromLayer always clears everything first — so only the changed venue's rings were redrawn and all others disappeared. Removed the objectIds pass-through so every triggered redraw is always a full scan.

- Simplified interceptor callbacks — The setTimeout(() => that.#processPlaces(), 0) wrappers in both the getDetails and fetchFields interceptors were removed. The debounce inside #processPlaces() handles the async scheduling now.

- disable() cleans up debounce timer — Cancels any pending debounce on disable so a timer set just before turning GLE off can't fire and redraw after the layer is torn down.

- Updated README — Fixed inaccurate method names (GLE.refresh() and GLE.setStrings() don't exist), corrected the strings property names to match the actual code, and documented the new request behavior and layer-visibility gate.

- No breaking changes — Public API (enable(), disable(), showTempClosedPOIs, distanceLimit, strings) is unchanged.